### PR TITLE
chore: bump version 3.0.0 -> 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.0.0 — Rebrand and rewrite
+## v6.0.0 — Rebrand and rewrite
 
 First release under the new Packagist coordinate `scanii/scanii-php`.
 The PHP namespace stays `Scanii\…`; the migration is the install line.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Test credentials: key `key`, secret `secret`, endpoint `http://localhost:4000`.
 
 ```diff
 -"uvasoftware/scanii-php": "^5.0"
-+"scanii/scanii-php": "^3.0"
++"scanii/scanii-php": "^6.0"
 ```
 
 The PHP namespace is unchanged (`Scanii\…`). Other notable changes:

--- a/src/ScaniiClient.php
+++ b/src/ScaniiClient.php
@@ -24,7 +24,7 @@ use Scanii\Models\ScaniiProcessingResult;
  */
 final class ScaniiClient
 {
-    public const string VERSION = '3.0.0';
+    public const string VERSION = '6.0.0';
 
     private const string API_VERSION_PATH = '/v2.2';
     private const string DEFAULT_USER_AGENT_PREFIX = 'scanii-php/v';


### PR DESCRIPTION
## Summary

Follow-up to merged PR #136. The new `scanii/scanii-php` Packagist coordinate shares the GitHub repo (and therefore the git tag namespace) with the prior `uvasoftware/scanii-php` package — most recent existing tag is `v5.2.0`, so the next monotonically valid tag is `v6.0.0`. `v3.0.0` is taken by an 8-year-old release.

String-only update across:
- `src/ScaniiClient.php` — `VERSION` constant (drives the `User-Agent` header sent to the API; must match the released package version)
- `README.md` — migration diff line: `"scanii/scanii-php": "^3.0"` → `"^6.0"`
- `CHANGELOG.md` — release heading: `## v3.0.0` → `## v6.0.0`

`composer.json` has no `version` key (Composer convention; Packagist reads from git tags) — no change. Tests do not assert on User-Agent — no change.

## Test plan

- [x] `grep -rn "3\.0\.0" src/ tests/ composer.json README.md CHANGELOG.md` — zero matches after substitution
- [x] `composer validate --strict` — PASS
- [x] `php -l src/ScaniiClient.php` — PASS
- [x] `composer test` (PHPUnit 11.5.55) on darwin/arm64 against scanii-cli — 11 tests, 19 assertions, 0 failures, 0 errors, 2 skips (same baseline as PR #136: older scanii-cli image lacks the UUID signature and callback delivery)
- [x] PR CI green on PHP 8.4 + 8.5 × ubuntu / macos / windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)