### PR TITLE
feat: v2.2 surface — retrieveTrace, processFromUrl, error field deprecation (6.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [6.2.0] — v2.2 surface
+
+### Added
+
+- `ScaniiClient::retrieveTrace(string $id): ?ScaniiTraceResult` — retrieves the
+  ordered processing event trace for a scan via `GET /files/{id}/trace`. Returns
+  `null` on 404 (no trace for that id). v2.2 preview surface; API shape may
+  shift before marked stable.
+- `ScaniiClient::processFromUrl(string $location, ?string $callback, ?array $metadata): ScaniiProcessingResult` —
+  submits a URL for synchronous scanning via `POST /files` with `location` as a
+  multipart/form-data field. Distinct from `fetch()`, which submits to
+  `/files/fetch` for asynchronous server-side fetching. `$location` must be a
+  string URL. v2.2 preview surface.
+- `Scanii\Models\ScaniiTraceResult` — new result class with `resourceId`,
+  `events` (`list<ScaniiTraceEvent>`), and the inherited `ScaniiResult` header
+  fields.
+- `Scanii\Models\ScaniiTraceEvent` — new model with `?string $timestamp` and
+  `string $message`.
+
+### Deprecated
+
+- `ScaniiProcessingResult::$error` — the server never populates this field on
+  successful responses; errors arrive as `ScaniiException` subclasses on non-2xx
+  HTTP responses. The field is retained for backwards compatibility. Will be
+  removed in a future major version.
+
+---
+
 ## v6.1.0 — Streaming standardization
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ echo implode(', ', $result->findings);
 fclose($stream);
 ```
 
+## API
+
+| Method | REST | Returns |
+|---|---|---|
+| `process($path, $metadata, $callback)` | `POST /files` | `ScaniiProcessingResult` |
+| `processStream($stream, $filename, $contentType, $metadata, $callback)` | `POST /files` | `ScaniiProcessingResult` |
+| `processAsync($path, $metadata, $callback)` | `POST /files/async` | `ScaniiPendingResult` |
+| `processAsyncStream($stream, $filename, $contentType, $metadata, $callback)` | `POST /files/async` | `ScaniiPendingResult` |
+| `processFromUrl($location, $callback, $metadata)` | `POST /files` | `ScaniiProcessingResult` (v2.2 preview) |
+| `fetch($location, $metadata, $callback)` | `POST /files/fetch` | `ScaniiPendingResult` |
+| `retrieve($id)` | `GET /files/{id}` | `ScaniiProcessingResult` |
+| `retrieveTrace($id)` | `GET /files/{id}/trace` | `?ScaniiTraceResult` (v2.2 preview) |
+| `ping()` | `GET /ping` | `bool` |
+| `createAuthToken($timeoutSeconds)` | `POST /auth/tokens` | `ScaniiAuthToken` |
+| `retrieveAuthToken($id)` | `GET /auth/tokens/{id}` | `ScaniiAuthToken` |
+| `deleteAuthToken($id)` | `DELETE /auth/tokens/{id}` | `void` |
+| `retrieveAccountInfo()` | `GET /account.json` | `ScaniiAccountInfo` |
+
+Full API reference: <https://scanii.github.io/openapi/v22/>.
+
 ## Regional endpoints
 
 | Constant | Endpoint |

--- a/src/Models/ScaniiProcessingResult.php
+++ b/src/Models/ScaniiProcessingResult.php
@@ -26,6 +26,9 @@ final class ScaniiProcessingResult extends ScaniiResult
         public readonly ?string $checksum,
         public readonly ?string $creationDate,
         public readonly array $metadata,
+        /**
+         * @deprecated 6.2.0 Errors arrive as ScaniiException subclasses on non-2xx responses; this field is never populated on success. Will be removed in a future major version.
+         */
         public readonly ?string $error = null,
         ?string $requestId = null,
         ?string $hostId = null,

--- a/src/Models/ScaniiTraceEvent.php
+++ b/src/Models/ScaniiTraceEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scanii\Models;
+
+/**
+ * A single processing event within a ScaniiTraceResult.
+ *
+ * @see https://scanii.github.io/openapi/v22/
+ */
+final class ScaniiTraceEvent
+{
+    public function __construct(
+        public readonly ?string $timestamp,
+        public readonly string $message,
+    ) {
+    }
+}

--- a/src/Models/ScaniiTraceResult.php
+++ b/src/Models/ScaniiTraceResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scanii\Models;
+
+/**
+ * Result of ScaniiClient::retrieveTrace — ordered processing events for a scan.
+ *
+ * This is a v2.2 preview surface; the API shape may shift before it is marked
+ * stable.
+ *
+ * @see https://scanii.github.io/openapi/v22/ — GET /files/{id}/trace
+ */
+final class ScaniiTraceResult extends ScaniiResult
+{
+    /**
+     * @param list<ScaniiTraceEvent> $events
+     */
+    public function __construct(
+        int $statusCode,
+        string $rawResponse,
+        public readonly string $resourceId,
+        public readonly array $events,
+        ?string $requestId = null,
+        ?string $hostId = null,
+        ?string $resourceLocation = null,
+    ) {
+        parent::__construct($statusCode, $rawResponse, $requestId, $hostId, $resourceLocation);
+    }
+}

--- a/src/ScaniiClient.php
+++ b/src/ScaniiClient.php
@@ -12,6 +12,8 @@ use Scanii\Models\ScaniiAccountInfoUser;
 use Scanii\Models\ScaniiAuthToken;
 use Scanii\Models\ScaniiPendingResult;
 use Scanii\Models\ScaniiProcessingResult;
+use Scanii\Models\ScaniiTraceEvent;
+use Scanii\Models\ScaniiTraceResult;
 
 /**
  * Thread-friendly client for the Scanii content processing API.
@@ -266,6 +268,69 @@ final class ScaniiClient
     }
 
     /**
+     * Retrieve the ordered processing event trace for a scan by id.
+     *
+     * Returns null when no trace exists for the given id (HTTP 404).
+     *
+     * This is a v2.2 preview surface; the API shape may shift before it is
+     * marked stable.
+     *
+     * @see https://scanii.github.io/openapi/v22/ — GET /files/{id}/trace
+     */
+    public function retrieveTrace(string $id): ?ScaniiTraceResult
+    {
+        if ($id === '') {
+            throw new InvalidArgumentException('id must not be empty');
+        }
+
+        [$status, $body, $headers] = $this->request('GET', '/files/' . rawurlencode($id) . '/trace');
+
+        if ($status === 404) {
+            return null;
+        }
+
+        if ($status !== 200) {
+            $this->throwForStatus($status, $body, $headers);
+        }
+
+        return $this->buildTraceResult($status, $body, $headers);
+    }
+
+    /**
+     * Submit a remote URL for synchronous scanning.
+     *
+     * $location must be a string URL. The URL is sent as a multipart/form-data
+     * field to POST /files; the Scanii server fetches and scans it
+     * synchronously. This is distinct from fetch(), which submits to
+     * POST /files/fetch for asynchronous server-side fetching.
+     *
+     * This is a v2.2 preview surface; the API shape may shift before it is
+     * marked stable.
+     *
+     * @param array<string, string>|null $metadata
+     *
+     * @see https://scanii.github.io/openapi/v22/ — POST /files
+     */
+    public function processFromUrl(
+        string $location,
+        ?string $callback = null,
+        ?array $metadata = null,
+    ): ScaniiProcessingResult {
+        if ($location === '') {
+            throw new InvalidArgumentException('location must not be empty');
+        }
+
+        $fields = $this->buildUrlMultipart($location, $metadata ?? [], $callback);
+        [$status, $body, $headers] = $this->request('POST', '/files', body: $fields);
+
+        if ($status !== 201) {
+            $this->throwForStatus($status, $body, $headers);
+        }
+
+        return $this->buildProcessingResult($status, $body, $headers);
+    }
+
+    /**
      * Verify that the configured credentials reach the API.
      *
      * @see https://scanii.github.io/openapi/v22/ — GET /ping
@@ -451,6 +516,28 @@ final class ScaniiClient
         return $fields;
     }
 
+    /**
+     * Build a cURL multipart fields array for processFromUrl (text fields only,
+     * no file part). When passed as CURLOPT_POSTFIELDS, cURL sends the request
+     * as multipart/form-data — the cli rejects urlencoded bodies on POST /files
+     * with MethodNotAllowed.
+     *
+     * @param array<string, string> $metadata
+     *
+     * @return array<string, string>
+     */
+    private function buildUrlMultipart(string $location, array $metadata, ?string $callback): array
+    {
+        $fields = ['location' => $location];
+        if ($callback !== null && $callback !== '') {
+            $fields['callback'] = $callback;
+        }
+        foreach ($metadata as $k => $v) {
+            $fields["metadata[$k]"] = $v;
+        }
+        return $fields;
+    }
+
     private function assertReadable(string $path): void
     {
         if (!is_file($path) || !is_readable($path)) {
@@ -613,6 +700,33 @@ final class ScaniiClient
             statusCode: $status,
             rawResponse: $body,
             resourceId: (string) ($json['id'] ?? ''),
+            requestId: $requestId,
+            hostId: $hostId,
+            resourceLocation: $location,
+        );
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function buildTraceResult(int $status, string $body, array $headers): ScaniiTraceResult
+    {
+        $json = $this->decodeJson($body);
+        [$requestId, $hostId, $location] = $this->commonMetadata($headers);
+
+        $events = [];
+        foreach (($json['events'] ?? []) as $e) {
+            $events[] = new ScaniiTraceEvent(
+                timestamp: isset($e['timestamp']) ? (string) $e['timestamp'] : null,
+                message: (string) ($e['message'] ?? ''),
+            );
+        }
+
+        return new ScaniiTraceResult(
+            statusCode: $status,
+            rawResponse: $body,
+            resourceId: (string) ($json['id'] ?? ''),
+            events: $events,
             requestId: $requestId,
             hostId: $hostId,
             resourceLocation: $location,

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -7,6 +7,8 @@ namespace Scanii\Tests;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Scanii\Models\ScaniiTraceEvent;
+use Scanii\Models\ScaniiTraceResult;
 use Scanii\ScaniiAuthException;
 use Scanii\ScaniiClient;
 
@@ -213,6 +215,50 @@ final class IntegrationTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         // @phpstan-ignore-next-line (intentional wrong type for test)
         $this->client()->processStream('not-a-stream', 'file.bin');
+    }
+
+    // -- retrieveTrace (v2.2 preview) ----------------------------------------
+
+    #[Test]
+    public function retrieve_trace_returns_non_empty_events_for_known_id(): void
+    {
+        $path = $this->tempFile(self::LOCAL_MALWARE_UUID);
+        try {
+            $result = $this->client()->process($path);
+            $trace = $this->client()->retrieveTrace($result->resourceId);
+
+            $this->assertNotNull($trace, 'retrieveTrace must return a ScaniiTraceResult for a known id');
+            $this->assertInstanceOf(ScaniiTraceResult::class, $trace);
+            $this->assertNotEmpty($trace->events, 'events array must be non-empty for a known processing id');
+            foreach ($trace->events as $event) {
+                $this->assertInstanceOf(ScaniiTraceEvent::class, $event);
+            }
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function retrieve_trace_returns_null_for_unknown_id(): void
+    {
+        $result = $this->client()->retrieveTrace('does-not-exist-trace-php');
+        $this->assertNull($result);
+    }
+
+    // -- processFromUrl (v2.2 preview) ---------------------------------------
+
+    #[Test]
+    public function process_from_url_returns_result_with_eicar_finding(): void
+    {
+        $url = self::CLI_TARGET . '/static/eicar.txt';
+        $result = $this->client()->processFromUrl($url);
+
+        $this->assertNotNull($result);
+        $this->assertContains(
+            'content.malicious.eicar-test-signature',
+            $result->findings,
+            'expected EICAR finding; got: ' . implode(', ', $result->findings),
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Add `ScaniiTraceEvent` and `ScaniiTraceResult` model classes under `Scanii\Models`
- Add `ScaniiClient::retrieveTrace(string $id): ?ScaniiTraceResult` — `GET /v2.2/files/{id}/trace`; returns `null` on 404, matching the null-on-404 convention across the SDK family
- Add `ScaniiClient::processFromUrl(string $location, ?string $callback, ?array $metadata): ScaniiProcessingResult` — `POST /v2.2/files` with `location` as a `multipart/form-data` field (NOT urlencoded; cli rejects urlencoded with `MethodNotAllowed`, confirmed across dotnet 7.1.0 / node 1.2.0 / ruby 1.2.0 / go 2.1.0)
- `@deprecated 6.2.0` `ScaniiProcessingResult::$error` via PHPDoc per CLAUDE.md §6; field retained for backwards compatibility
- No `composer.json` version bump — Packagist reads from git tags; Rafael cuts `v6.2.0` after merge

## Test plan

- [ ] `vendor/bin/phpunit --testdox` — 18 tests PASS, 1 SKIP (pre-existing `callback_delivery` self-skip)
- [ ] New tests: `retrieve_trace_returns_non_empty_events_for_known_id`, `retrieve_trace_returns_null_for_unknown_id`, `process_from_url_returns_result_with_eicar_finding` — all three hard-assert, no self-skip
- [ ] CI matrix (PHP 8.4 + 8.5 × ubuntu/macos/windows) will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)