### PR TITLE
deprecate-auto-endpoint: deprecate ScaniiTarget::AUTO, fix VERSION constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [6.3.0] — deprecate AUTO endpoint
+
+### Deprecated
+
+- `ScaniiTarget::AUTO` — latency-based routing does not guarantee which region processes your
+  data. Use an explicit regional constant (`ScaniiTarget::US1`, `ScaniiTarget::EU1`, etc.)
+  for data residency compliance. Will be removed in a future major version.
+- Calling `ScaniiClient::create()` or `ScaniiClient::createFromToken()` without an explicit
+  `$target` (or with `ScaniiTarget::AUTO`) now emits an `E_USER_DEPRECATED` notice.
+
+### Fixed
+
+- `ScaniiClient::VERSION` constant corrected from `6.1.0` to `6.3.0` (was stale since 6.2.0).
+
 ## [6.2.0] — v2.2 surface
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Requires PHP 8.4 or newer.
 
 ```php
 use Scanii\ScaniiClient;
+use Scanii\ScaniiTarget;
 
-$client = ScaniiClient::create('your-api-key', 'your-api-secret');
+$client = ScaniiClient::create('your-api-key', 'your-api-secret', ScaniiTarget::US1);
 
 // Scan a file from disk:
 $result = $client->process('/path/to/file');
@@ -71,13 +72,13 @@ Full API reference: <https://scanii.github.io/openapi/v22/>.
 
 | Constant | Endpoint |
 |---|---|
-| `ScaniiTarget::AUTO` | `https://api.scanii.com` |
 | `ScaniiTarget::US1` | `https://api-us1.scanii.com` |
 | `ScaniiTarget::EU1` | `https://api-eu1.scanii.com` |
 | `ScaniiTarget::EU2` | `https://api-eu2.scanii.com` |
 | `ScaniiTarget::AP1` | `https://api-ap1.scanii.com` |
 | `ScaniiTarget::AP2` | `https://api-ap2.scanii.com` |
 | `ScaniiTarget::CA1` | `https://api-ca1.scanii.com` |
+| ~~`ScaniiTarget::AUTO`~~ | ~~`https://api.scanii.com`~~ — **deprecated**, does not guarantee regional data placement |
 
 Pass any string URL for a custom or local endpoint:
 

--- a/src/ScaniiClient.php
+++ b/src/ScaniiClient.php
@@ -26,7 +26,7 @@ use Scanii\Models\ScaniiTraceResult;
  */
 final class ScaniiClient
 {
-    public const string VERSION = '6.1.0';
+    public const string VERSION = '6.3.0';
 
     private const string API_VERSION_PATH = '/v2.2';
     private const string DEFAULT_USER_AGENT_PREFIX = 'scanii-php/v';
@@ -64,6 +64,12 @@ final class ScaniiClient
 
     /**
      * Build a client with API key + secret credentials.
+     *
+     * @param string $target Regional endpoint. Defaults to {@see ScaniiTarget::AUTO}.
+     *   @deprecated Omitting $target (or passing ScaniiTarget::AUTO) uses latency-based
+     *     routing and does not guarantee regional data placement. Pass an explicit regional
+     *     constant (ScaniiTarget::US1, ScaniiTarget::EU1, etc.) for data residency compliance.
+     *     Will be removed in a future major version.
      */
     public static function create(
         string $key,
@@ -74,17 +80,43 @@ final class ScaniiClient
         if ($secret === '') {
             throw new InvalidArgumentException('secret must not be empty; use createFromToken() for token-based auth');
         }
+        if ($target === ScaniiTarget::AUTO) {
+            trigger_error(
+                '[scanii] DEPRECATION: No explicit target passed to ScaniiClient::create(); ' .
+                'defaulting to ScaniiTarget::AUTO (https://api.scanii.com). ' .
+                'This does not guarantee regional data placement. ' .
+                'Pass ScaniiTarget::US1 (or another regional constant) for explicit data residency control. ' .
+                'ScaniiTarget::AUTO will be removed in a future major version.',
+                E_USER_DEPRECATED,
+            );
+        }
         return new self($key, $secret, $target, $userAgent);
     }
 
     /**
      * Build a client that authenticates with a previously minted auth token.
+     *
+     * @param string $target Regional endpoint. Defaults to {@see ScaniiTarget::AUTO}.
+     *   @deprecated Omitting $target (or passing ScaniiTarget::AUTO) uses latency-based
+     *     routing and does not guarantee regional data placement. Pass an explicit regional
+     *     constant (ScaniiTarget::US1, ScaniiTarget::EU1, etc.) for data residency compliance.
+     *     Will be removed in a future major version.
      */
     public static function createFromToken(
         ScaniiAuthToken $token,
         string $target = ScaniiTarget::AUTO,
         string $userAgent = '',
     ): self {
+        if ($target === ScaniiTarget::AUTO) {
+            trigger_error(
+                '[scanii] DEPRECATION: No explicit target passed to ScaniiClient::createFromToken(); ' .
+                'defaulting to ScaniiTarget::AUTO (https://api.scanii.com). ' .
+                'This does not guarantee regional data placement. ' .
+                'Pass ScaniiTarget::US1 (or another regional constant) for explicit data residency control. ' .
+                'ScaniiTarget::AUTO will be removed in a future major version.',
+                E_USER_DEPRECATED,
+            );
+        }
         return new self($token->resourceId, '', $target, $userAgent);
     }
 

--- a/src/ScaniiTarget.php
+++ b/src/ScaniiTarget.php
@@ -12,6 +12,14 @@ namespace Scanii;
  */
 final class ScaniiTarget
 {
+    /**
+     * Latency-routed endpoint. Routes to the nearest region automatically,
+     * but does not guarantee which region processes your data.
+     *
+     * @deprecated Use an explicit regional constant for data residency compliance:
+     *   {@see US1}, {@see EU1}, {@see EU2}, {@see AP1}, {@see AP2}, {@see CA1}.
+     *   Will be removed in a future major version.
+     */
     public const string AUTO = 'https://api.scanii.com';
     public const string US1 = 'https://api-us1.scanii.com';
     public const string EU1 = 'https://api-eu1.scanii.com';


### PR DESCRIPTION
## Summary

- `ScaniiTarget::AUTO` annotated with `@deprecated` PHPDoc
- `ScaniiClient::create()` and `::createFromToken()` emit `trigger_error(E_USER_DEPRECATED)` when `$target === ScaniiTarget::AUTO`
- `ScaniiClient::VERSION` constant fixed from stale `6.1.0` to `6.3.0` (was not bumped in the 6.2.0 PR)
- Version `6.2.0` → `6.3.0`

Part of [uvasoftware/sdks#1](https://github.com/uvasoftware/sdks/issues/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)