### PR TITLE
Refresh dev dependencies and CI actions; prep 6.3.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         php: ['8.4', '8.5']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,7 +33,7 @@ jobs:
         run: composer validate --strict
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/composer
           key: composer-${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('composer.json') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Changed
 
-- Refreshed `composer.lock` within existing ranges: phpunit 11.5.55 → 11.5.56 (dev-only;
-  the library's runtime requirements — `php`, `ext-curl`, `ext-json` — are unchanged).
 - Bumped CI actions: `actions/checkout` v4 → v7, `actions/cache` v4 → v6.
+  (Dev dependencies float within `composer.json` ranges — `composer.lock` is intentionally
+  not committed for this library, so phpunit resolves to the latest 11.x at install time;
+  runtime requirements — `php`, `ext-curl`, `ext-json` — are unchanged.)
 - `ScaniiClient::VERSION` constant bumped to `6.3.1`.
 
 ## [6.3.0] — deprecate AUTO endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [6.3.1] — dependency refresh
+
+### Changed
+
+- Refreshed `composer.lock` within existing ranges: phpunit 11.5.55 → 11.5.56 (dev-only;
+  the library's runtime requirements — `php`, `ext-curl`, `ext-json` — are unchanged).
+- Bumped CI actions: `actions/checkout` v4 → v7, `actions/cache` v4 → v6.
+- `ScaniiClient::VERSION` constant bumped to `6.3.1`.
+
 ## [6.3.0] — deprecate AUTO endpoint
 
 ### Deprecated

--- a/src/ScaniiClient.php
+++ b/src/ScaniiClient.php
@@ -26,7 +26,7 @@ use Scanii\Models\ScaniiTraceResult;
  */
 final class ScaniiClient
 {
-    public const string VERSION = '6.3.0';
+    public const string VERSION = '6.3.1';
 
     private const string API_VERSION_PATH = '/v2.2';
     private const string DEFAULT_USER_AGENT_PREFIX = 'scanii-php/v';


### PR DESCRIPTION
Conservative dependency refresh (CI/dev only — runtime requires stay `php` + `ext-curl` + `ext-json`):

- `actions/checkout` v4 → v7, `actions/cache` v4 → v6
- `ScaniiClient::VERSION` → 6.3.1 (the constant that went stale before 6.3.0) + CHANGELOG entry
- Note: `composer.lock` is gitignored for this library, so there is no lock to bump — phpunit floats within `^11.0` and already resolves to the current 11.5.56 at install time (verified locally)
- No composer.json version field (Packagist reads tags); release will be the v6.3.1 tag

Local phpunit run against scanii-cli: 18 tests, 17 pass, 1 skipped (callback self-skip).